### PR TITLE
Set version to 1.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
     id 'org.asciidoctor.convert' version '1.5.3'
 }
 
-version "1.0.0.BUILD-SNAPSHOT"
+version "1.0.0"
 group "org.grails.plugins"
 
 apply plugin:"org.grails.grails-plugin"


### PR DESCRIPTION
As we've been using this plugin for more than a couple of years, it's safe to bump the version to a stable 1.0.0.